### PR TITLE
style(ui): improve mobile layout

### DIFF
--- a/algorithm-game/styles.css
+++ b/algorithm-game/styles.css
@@ -168,3 +168,10 @@ footer{color:var(--muted); border-top:1px solid var(--line)}
 .onboarding__list li{display:flex; align-items:center; gap:12px;}
 .onboarding__checkbox{font-size:13px; color:var(--muted); display:flex; align-items:center; gap:6px;}
 kbd{background:#f1f4fb; border:1px solid var(--line); border-radius:6px; padding:4px 6px; font-size:13px; font-family:'JetBrains Mono','SFMono-Regular',monospace;}
+
+@media (max-width:768px){
+  main{flex-direction:column;}
+  .left{width:100%;}
+  .right{align-items:stretch;}
+  .right canvas#game{width:100%; max-width:100%;}
+}


### PR DESCRIPTION
## Summary
- add a mobile breakpoint to stack the main layout vertically
- allow the left control panel and canvas to stretch to full width on small screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3dabc25ac832b82bcd6313f3d1f1a